### PR TITLE
Dynamic slots

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -145,7 +145,7 @@ if ESX.GetConfig().Multichar then
 	AddEventHandler('esx_multicharacter:SetupUI', function(data, slots)
 		DoScreenFadeOut(0)
 		Characters = data
-		local Slots = slots
+		local slots = slots
 		local elements = {}
 		local Character = next(Characters)
 		exports.spawnmanager:forceRespawn()
@@ -180,7 +180,7 @@ if ESX.GetConfig().Multichar then
 				local label = v.firstname..' '..v.lastname
 				elements[#elements+1] = {label = label, value = v.id}
 			end
-			if #elements < Slots then
+			if #elements < slots then
 				elements[#elements+1] = {label = _('create_char'), value = (#elements+1), new = true}
 			end
 			ESX.UI.Menu.Open('default', GetCurrentResourceName(), 'selectchar', {
@@ -229,7 +229,7 @@ if ESX.GetConfig().Multichar then
 				else
 					ESX.UI.Menu.CloseAll()
 					local GetSlot = function()
-						for i=1, Slots do
+						for i=1, slots do
 							if not Characters[i] then
 								return i
 							end

--- a/client/main.lua
+++ b/client/main.lua
@@ -142,9 +142,10 @@ if ESX.GetConfig().Multichar then
 	end
 	
 	RegisterNetEvent('esx_multicharacter:SetupUI')
-	AddEventHandler('esx_multicharacter:SetupUI', function(data)
+	AddEventHandler('esx_multicharacter:SetupUI', function(data, slots)
 		DoScreenFadeOut(0)
 		Characters = data
+		local Slots = slots
 		local elements = {}
 		local Character = next(Characters)
 		exports.spawnmanager:forceRespawn()
@@ -179,7 +180,7 @@ if ESX.GetConfig().Multichar then
 				local label = v.firstname..' '..v.lastname
 				elements[#elements+1] = {label = label, value = v.id}
 			end
-			if #elements < Config.Slots then
+			if #elements < Slots then
 				elements[#elements+1] = {label = _('create_char'), value = (#elements+1), new = true}
 			end
 			ESX.UI.Menu.Open('default', GetCurrentResourceName(), 'selectchar', {
@@ -228,7 +229,7 @@ if ESX.GetConfig().Multichar then
 				else
 					ESX.UI.Menu.CloseAll()
 					local GetSlot = function()
-						for i=1, Config.Slots do
+						for i=1, Slots do
 							if not Characters[i] then
 								return i
 							end

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,7 @@
 Config = {}
 Config.Locale = 'en'
 
+Config.Slots = 1
 Config.Spawn = vector4(-113.7, 565.3, 195.2, 0) -- Sets the location for character selection
 -- To set the spawn location for new characters, modify the default value in the `users` SQL table
 

--- a/config.lua
+++ b/config.lua
@@ -1,7 +1,6 @@
 Config = {}
 Config.Locale = 'en'
 
-Config.Slots = 4
 Config.Spawn = vector4(-113.7, 565.3, 195.2, 0) -- Sets the location for character selection
 -- To set the spawn location for new characters, modify the default value in the `users` SQL table
 

--- a/esx_multicharacter.sql
+++ b/esx_multicharacter.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `multicharacter_slots` (
+	`identifier` VARCHAR(60) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
+	`slots` INT(11) NOT NULL DEFAULT '1'
+)
+COLLATE='utf8mb4_unicode_ci'
+ENGINE=InnoDB
+;

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -8,4 +8,11 @@ Locales['en'] = {
 	['char_delete'] = "Delete this character",
 	['cancel'] = "Cancel",
 	['confirm'] = "Confirm",
+	['command_setslots'] = "Set multicharacter slots number of a player",
+	['command_remslots'] = "Remove multicharacter slots number of a player",
+	['command_identifier'] = "Player identifier",
+	['command_slots'] = "# of slots",
+	['slotsadd'] = "You added %s slots to %s",
+	['slotsedit'] = "You set %s slots to %s",
+	['slotsrem'] = "You removed slots to %s",
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -15,6 +15,9 @@ elseif ESX.GetConfig().Multichar == true then
 		local slots = MySQL.Sync.fetchScalar("SELECT `slots` FROM `multicharacter_slots` WHERE identifier = ?", {
 			ESX.GetIdentifier(playerId)
 		})
+		if not slots then
+			slots = Config.Slots
+		end
 		MySQL.Async.fetchAll(Fetch, {
 			identifier,
 			slots
@@ -126,26 +129,23 @@ elseif ESX.GetConfig().Multichar == true then
 		TriggerEvent('esx:playerLogout', src)
 	end)
 
-	AddEventHandler('playerConnecting', function()
-		local src = source
-		local identifier = false
+	RegisterCommand('setslots', function(source, args, rawCommand)
 
-		for k,v in pairs(GetPlayerIdentifiers(source)) do
-			if string.sub(v, 1, string.len("license:")) == "license:" then
-				identifier = string.sub(v, 9)
-			end
-		end
+		-- slice args and take license and slots count
 
 		local slots = MySQL.Sync.fetchScalar("SELECT `slots` FROM `multicharacter_slots` WHERE identifier = ?", {
 			identifier
 		})
 
 		if slots == nil then
-			MySQL.Async.execute('INSERT INTO multicharacter_slots (identifier, slots) VALUES (?, 1)', {
-				identifier
-			})
+			-- insert query
+			-- MySQL.Async.execute('INSERT INTO multicharacter_slots (identifier, slots) VALUES (?, 1)', {
+			-- 	identifier
+			-- })
+		else
+			-- alter table
 		end
-	end)
+	end, true)
 
 	RegisterCommand('forcelog', function(source, args, rawCommand)
 		TriggerEvent('esx:playerLogout', source)

--- a/server/main.lua
+++ b/server/main.lua
@@ -12,12 +12,12 @@ elseif ESX.GetConfig().Multichar == true then
 	local SetupCharacters = function(playerId)
 		while Fetch == -1 do Citizen.Wait(500) end
 		local identifier = Config.Prefix..'%:'..ESX.GetIdentifier(playerId)
-		local slots = MySQL.Sync.fetchScalar("SELECT `slots` FROM `multicharacter_slots` WHERE identifier LIKE @identifier", {
-			['@identifier'] = ESX.GetIdentifier(playerId)
+		local slots = MySQL.Sync.fetchScalar("SELECT `slots` FROM `multicharacter_slots` WHERE identifier = ?", {
+			ESX.GetIdentifier(playerId)
 		})
 		MySQL.Async.fetchAll(Fetch, {
 			identifier,
-			Config.Slots
+			slots
 		}, function(result)
 			local characters = {}
 			for i=1, #result, 1 do
@@ -41,7 +41,7 @@ elseif ESX.GetConfig().Multichar == true then
 				}
 				if result[i].sex == 'm' then characters[id].sex = _('male') else characters[id].sex = _('female') end
 			end
-			TriggerClientEvent('esx_multicharacter:SetupUI', playerId, characters, slost)
+			TriggerClientEvent('esx_multicharacter:SetupUI', playerId, characters, slots)
 		end)
 	end
 
@@ -136,13 +136,13 @@ elseif ESX.GetConfig().Multichar == true then
 			end
 		end
 
-		local slots = MySQL.Sync.fetchScalar("SELECT `slots` FROM `multicharacter_slots` WHERE identifier LIKE @identifier", {
-			['@identifier'] = identifier
+		local slots = MySQL.Sync.fetchScalar("SELECT `slots` FROM `multicharacter_slots` WHERE identifier = ?", {
+			identifier
 		})
 
 		if slots == nil then
-			MySQL.Async.execute('INSERT INTO multicharacter_slots (identifier, slots) VALUES (@identifier, 1)', {
-				['@identifier'] = identifier
+			MySQL.Async.execute('INSERT INTO multicharacter_slots (identifier, slots) VALUES (?, 1)', {
+				identifier
 			})
 		end
 	end)


### PR DESCRIPTION
Hello,
this PR adds the dynamic slots feature: it means that you can set a custom amount of extra slots to specific users.
This is completely optional and it falls back to `Config.Slots` if the user is not in the database.
I added two commands `setslots` and `remslots` for in-game slots management.

Hope this is useful!