### PR TITLE
removed margin-right to just use "right" value

### DIFF
--- a/html/css/main.css
+++ b/html/css/main.css
@@ -25,10 +25,9 @@ body {
     display:none;
     position: absolute;
 	top: 50%;
-    right: 0;
+    right: 25;
     transform: translate(0, -50%);
 	background: rgba(0,0,0,0.7);
-	margin-right: 1.5rem;
 }
 
 .header {


### PR DESCRIPTION
Removed margin-right as "right" handles this usage just fine and margin messes with the actual container.